### PR TITLE
Remove `rel=feed` but keep `rel=alternative`

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,7 +10,6 @@
 
         {{ if .RSSLink }}
             <link href="{{ .RSSLink }}" title="{{ .Site.Title }}" type="application/rss+xml" rel="alternate">
-            <link href="{{ .RSSLink }}" title="{{ .Site.Title }}" type="application/rss+xml" rel="feed">
         {{ end }}
 
         {{ block "site/styles" . }}{{ partial "site/styles.html" . }}{{ end }}


### PR DESCRIPTION
Fixes: #8 

Seems this is kinda valid, but not enough to keep as a default. If you (or anyone) does want to support it, then it makes sense to add this per-project.

https://blog.whatwg.org/the-road-to-html-5-link-relations#rel-feed