### PR TITLE
Add ~ path support in sass

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -4,7 +4,8 @@ import gulp from 'gulp'
 import del from 'del'
 import runSequence from 'run-sequence'
 import gulpLoadPlugins from 'gulp-load-plugins'
-import { spawn } from "child_process";
+import { spawn } from "child_process"
+import tildeImporter from 'node-sass-tilde-importer'
 
 const $ = gulpLoadPlugins()
 const browserSync = require('browser-sync').create()
@@ -60,7 +61,7 @@ gulp.task('sass', () => {
     .pipe($.print())
     .pipe($.sassLint())
     .pipe($.sassLint.format())
-    .pipe($.sass({ precision: 5 }))
+    .pipe($.sass({ precision: 5, importer: tildeImporter }))
     .pipe($.autoprefixer(['ie >= 10', 'last 2 versions']))
     .pipe($.if(isProduction, $.cssnano({ discardUnused: false, minifyFontValues: false })))
     .pipe($.size({ gzip: true, showFiles: true }))

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "gulp-size": "^2.1.0",
     "gulp-uglify": "^3.0.0",
     "gulp-watch": "^4.3.11",
-    "run-sequence": "^2.0.0"
+    "run-sequence": "^2.0.0",
+    "node-sass-tilde-importer": "^1.0.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Fixes: #15

Allows you to import from `node_modules` like this `~bulma/bulma` (for example)