### PR TITLE
Don't open the browser when you run `npm run server`

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -21,7 +21,8 @@ gulp.task('server', ['build'], () => {
     browserSync.init({
         server: {
             baseDir: 'public'
-        }
+        },
+        open: false
     })
     $.watch('src/sass/**/*.scss', () => gulp.start('sass'))
     $.watch('src/js/**/*.js', () => gulp.start('js-watch'))


### PR DESCRIPTION
Fixes #20 

Just got really annoying whenever you had to re-run `npm run server` while in the middle of developing. You would have loads of copies of the site open.