### PR TITLE
Add support for .ico files in gulp -> images task

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -103,7 +103,7 @@ gulp.task('fonts', () => {
 });
 
 gulp.task('images', () => {
-    return gulp.src('src/images/**/*.{png,jpg,jpeg,gif,svg,webp}')
+    return gulp.src('src/images/**/*.{png,jpg,jpeg,gif,svg,webp,ico}')
         .pipe($.newer('static/images'))
         .pipe($.print())
         .pipe($.imagemin())


### PR DESCRIPTION
A good place to include favicon files is `/src/images` but these are not copied into `/static` as gulp doesn't recognise the file type.

This PR changes that.

Fixes #25 