### PR TITLE
Kill builds when Hugo fails, but only when not using BrowserSync

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -15,6 +15,8 @@ const onError = (err) => {
     console.log(err)
 }
 
+let suppressHugoErrors = false;
+
 // --
 
 gulp.task('server', ['build'], () => {
@@ -28,6 +30,7 @@ gulp.task('server:with-drafts', ['build-preview'], () => {
 });
 
 gulp.task('init-watch', () => {
+    suppressHugoErrors = true;
     browserSync.init({
         server: {
             baseDir: 'public'
@@ -54,8 +57,13 @@ gulp.task('hugo', (cb) => {
     let args = baseUrl ? ['-b', baseUrl] : [];
 
     return spawn('hugo', args, { stdio: 'inherit' }).on('close', (code) => {
-        browserSync.reload()
-        cb()
+        if (suppressHugoErrors || code === 0) {
+            browserSync.reload()
+            cb()
+        } else {
+            console.log('hugo command failed.');
+            cb('hugo command failed.');
+        }
     })
 })
 
@@ -68,8 +76,13 @@ gulp.task('hugo-preview', (cb) => {
         args.push(process.env.DEPLOY_PRIME_URL)
     }
     return spawn('hugo', args, { stdio: 'inherit' }).on('close', (code) => {
-        browserSync.reload()
-        cb()
+        if (suppressHugoErrors || code === 0) {
+            browserSync.reload()
+            cb()
+        } else {
+            console.log('hugo command failed.');
+            cb('hugo command failed.');
+        }
     })
 })
 


### PR DESCRIPTION
When Hugo currently errors out, the builds still pass, which causes Netlify to deploy broken sites.

This should fix that.