### PR TITLE
Update npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,21 +10,22 @@
     "cms:delete": "gulp cms-delete"
   },
   "dependencies": {
-    "babel-core": "^6.26.2",
-    "babel-preset-es2015": "^6.24.1",
-    "browser-sync": "^2.23.7",
+    "babel-core": "^6.26.3",
+    "babel-preset-env": "^1.7.0",
+    "babel-register": "^6.26.0",
+    "browser-sync": "^2.24.4",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^4.0.0",
-    "gulp-babel": "^6.1.2",
+    "gulp-babel": "^7.0.1",
     "gulp-concat": "^2.6.1",
     "gulp-cssnano": "^2.1.3",
     "gulp-if": "^2.0.2",
-    "gulp-imagemin": "^3.3.0",
+    "gulp-imagemin": "^4.1.0",
     "gulp-load-plugins": "^1.5.0",
     "gulp-newer": "^1.3.0",
     "gulp-plumber": "^1.1.0",
     "gulp-print": "^2.0.1",
-    "gulp-sass": "^3.2.1",
+    "gulp-sass": "^4.0.1",
     "gulp-sass-lint": "^1.3.2",
     "gulp-size": "^2.1.0",
     "gulp-uglify": "^3.0.0",
@@ -34,7 +35,7 @@
   },
   "babel": {
     "presets": [
-      "es2015"
+      "env"
     ]
   }
 }


### PR DESCRIPTION
`npm install` was failing on latest version of node.

These were the errors:

```charlies-mbp:atlas charliewalter$ npm install

> fsevents@1.1.3 install /Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/fsevents
> node install

node-pre-gyp ERR! Tried to download(404): https://fsevents-binaries.s3-us-west-2.amazonaws.com/v1.1.3/fse-v1.1.3-node-v64-darwin-x64.tar.gz 
node-pre-gyp ERR! Pre-built binaries not found for fsevents@1.1.3 and node@10.2.1 (node-v64 ABI, unknown) (falling back to source compile with node-gyp) 
node-pre-gyp ERR! Tried to download(undefined): https://fsevents-binaries.s3-us-west-2.amazonaws.com/v1.1.3/fse-v1.1.3-node-v64-darwin-x64.tar.gz 
node-pre-gyp ERR! Pre-built binaries not found for fsevents@1.1.3 and node@10.2.1 (node-v64 ABI, unknown) (falling back to source compile with node-gyp) 
  SOLINK_MODULE(target) Release/.node
  SOLINK_MODULE(target) Release/.node
  CXX(target) Release/obj.target/fse/fsevents.o
  CXX(target) Release/obj.target/fse/fsevents.o
In file included from ../fsevents.cc:6:
In file included from ../fsevents.cc:6:
../../nan/nan.h:839../../nan/nan.h::18839:: 18: warning: warning: 'MakeCallback''MakeCallback' is  deprecated:is  Usedeprecated:  MakeCallback(...,Use  async_context)MakeCallback(...,  [-Wdeprecated-declarations]async_context) 
[-Wdeprecated-declarations]
    return node::MakeCallback(    return node::MakeCallback(

                 ^                 ^

/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h:/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h171::1711::1 : note: note'MakeCallback':  has'MakeCallback'  beenhas  explicitlybeen  markedexplicitly  deprecatedmarked  heredeprecated 
here
NODE_DEPRECATED("Use MakeCallback(..., async_context)",
NODE_DEPRECATED("Use MakeCallback(..., async_context)",^

^
/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h:88/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h::2088:: 20: note: noteexpanded:  fromexpanded  macrofrom  'NODE_DEPRECATED'macro 
'NODE_DEPRECATED'
    __attribute__((deprecated(message))) declarator
    __attribute__((deprecated(message))) declarator                   ^

                   ^
In file included from ../fsevents.cc:6In file included from :
../fsevents.cc:../../nan/nan.h6::
854:../../nan/nan.h18::854 :18:warning : warning'MakeCallback':  is 'MakeCallback'deprecated:  isUse  deprecated:MakeCallback(...,  Useasync_context)  MakeCallback(...,[-Wdeprecated-declarations] async_context)
 [-Wdeprecated-declarations]
    return node::MakeCallback(
                 ^    return node::MakeCallback(

                 ^
/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h:164:/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h1::164 :1:note : 'MakeCallback'note : has 'MakeCallback'been  hasexplicitly  beenmarked  explicitlydeprecated  markedhere deprecated
 here
NODE_DEPRECATED("Use MakeCallback(..., async_context)",
NODE_DEPRECATED("Use MakeCallback(..., async_context)",^

^
/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h:88/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h::2088:: 20: note: expandednote : from macroexpanded  'NODE_DEPRECATED'from 
macro 'NODE_DEPRECATED'
    __attribute__((deprecated(message))) declarator
                   ^
    __attribute__((deprecated(message))) declarator
                   ^
In file included from ../fsevents.cc:6:
In file included from ../fsevents.cc../../nan/nan.h::8696::
18:../../nan/nan.h :869:warning18: : 'MakeCallback' warningis:  deprecated: 'MakeCallback'Use  isMakeCallback(...,  deprecated:async_context)  Use[-Wdeprecated-declarations] MakeCallback(...,
 async_context) [-Wdeprecated-declarations]
    return node::MakeCallback(
                 ^
    return node::MakeCallback(
                 ^
/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h:157:1/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h:: 157:1note::  'MakeCallback' notehas:  been'MakeCallback'  explicitlyhas  markedbeen  deprecatedexplicitly  heremarked 
deprecated here
NODE_DEPRECATED("Use MakeCallback(..., async_context)",
^NODE_DEPRECATED("Use MakeCallback(..., async_context)",

^
/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h:88:/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h20:: 88:20note::  expanded fromnote : macro 'NODE_DEPRECATED'expanded 
from macro 'NODE_DEPRECATED'
    __attribute__((deprecated(message))) declarator
                   ^
    __attribute__((deprecated(message))) declarator
                   ^
In file included from ../fsevents.cc:6:
../../nan/nan.h:1478:31: warning: 'MakeCallback' is deprecated: Use MakeCallback(..., async_context) [-Wdeprecated-declarations]
    return scope.Escape(node::MakeCallback(
                              ^
/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h:171:1: note: 'MakeCallback' has been explicitly marked deprecated here
In file included from ../fsevents.cc:6:
../../nan/nan.hNODE_DEPRECATED("Use MakeCallback(..., async_context)",:
1478:^31
: warning: /Users/charliewalter/.node-gyp/10.2.1/include/node/node.h'MakeCallback': 88is: 20deprecated: :Use  MakeCallback(..., async_context) [-Wdeprecated-declarations]note
: expanded from macro 'NODE_DEPRECATED'
    return scope.Escape(node::MakeCallback(
                              ^
/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h    __attribute__((deprecated(message))) declarator:
171:                   ^1
: note: 'MakeCallback' has been explicitly marked deprecated here
NODE_DEPRECATED("Use MakeCallback(..., async_context)",
^
/Users/charliewalter/.node-gyp/10.2.1/include/node/node.h:88:20: note: expanded from macro 'NODE_DEPRECATED'
    __attribute__((deprecated(message))) declarator
                   ^
4 warnings generated.
4 warnings generated.
rm: ./Release/.deps/Release/obj.target/fse/fsevents.o.d.raw: No such file or directory
make: *** [Release/obj.target/fse/fsevents.o] Error 1
gyp  SOLINK_MODULE(target) Release/fse.node
 ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:258:23)
gyp ERR! stack     at ChildProcess.emit (events.js:182:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:237:12)
gyp ERR! System Darwin 17.5.0
gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "build" "--fallback-to-build" "--module=/Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/fsevents/lib/binding/Release/node-v64-darwin-x64/fse.node" "--module_name=fse" "--module_path=/Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/fsevents/lib/binding/Release/node-v64-darwin-x64"
gyp ERR! cwd /Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/fsevents
gyp ERR! node -v v10.2.1
gyp ERR! node-gyp -v v3.6.2
gyp ERR! not ok 
node-pre-gyp ERR! build error 
node-pre-gyp ERR! stack Error: Failed to execute '/usr/local/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/fsevents/lib/binding/Release/node-v64-darwin-x64/fse.node --module_name=fse --module_path=/Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/fsevents/lib/binding/Release/node-v64-darwin-x64' (1)
node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/fsevents/node_modules/node-pre-gyp/lib/util/compile.js:83:29)
node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:182:13)
node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:961:16)
node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:248:5)
node-pre-gyp ERR! System Darwin 17.5.0
node-pre-gyp ERR! command "/usr/local/bin/node" "/Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/fsevents/node_modules/node-pre-gyp/bin/node-pre-gyp" "install" "--fallback-to-build"
node-pre-gyp ERR! cwd /Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/fsevents
node-pre-gyp ERR! node -v v10.2.1
node-pre-gyp ERR! node-pre-gyp -v v0.6.39
node-pre-gyp ERR! not ok 
Failed to execute '/usr/local/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/fsevents/lib/binding/Release/node-v64-darwin-x64/fse.node --module_name=fse --module_path=/Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/fsevents/lib/binding/Release/node-v64-darwin-x64' (1)
  COPY /Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/fsevents/lib/binding/Release/node-v64-darwin-x64/fse.node
  TOUCH Release/obj.target/action_after_build.stamp

> uws@9.14.0 install /Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/uws
> node-gyp rebuild > build_log.txt 2>&1 || exit 0


> node-sass@4.9.0 install /Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/node-sass
> node scripts/install.js

Cached binary found at /Users/charliewalter/.npm/node-sass/4.9.0/darwin-x64-64_binding.node

> node-sass@4.9.0 postinstall /Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/node-sass
> node scripts/build.js

Binary found at /Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/node-sass/vendor/darwin-x64-64/binding.node
Testing binary
Binary is fine

> gifsicle@3.0.4 postinstall /Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/gifsicle
> node lib/install.js

  ✔ gifsicle pre-build test passed successfully

> jpegtran-bin@3.2.0 postinstall /Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/jpegtran-bin
> node lib/install.js

  ✔ jpegtran pre-build test passed successfully

> optipng-bin@3.1.4 postinstall /Users/charliewalter/Desktop/atlascleantest/atlas/node_modules/optipng-bin
> node lib/install.js

  ✔ optipng pre-build test passed successfully
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.1.3 (node_modules/fsevents):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.1.3 install: `node install`
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: Exit status 1

added 1227 packages from 686 contributors in 26.213s
charlies-mbp:atlas charliewalter$ npm run server

> atlas@ server /Users/charliewalter/Desktop/atlascleantest/atlas
> gulp server

[16:44:23] Failed to load external module @babel/register
[16:44:23] Requiring external module babel-register
gulp[77093]: ../src/node_contextify.cc:629:static void node::contextify::ContextifyScript::New(const FunctionCallbackInfo<v8::Value> &): Assertion `args[1]->IsString()' failed.
 1: node::Abort() [/usr/local/bin/node]
 2: node::MakeCallback(v8::Isolate*, v8::Local<v8::Object>, char const*, int, v8::Local<v8::Value>*, node::async_context) [/usr/local/bin/node]
 3: node::contextify::ContextifyScript::New(v8::FunctionCallbackInfo<v8::Value> const&) [/usr/local/bin/node]
 4: v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo*) [/usr/local/bin/node]
 5: v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<true>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) [/usr/local/bin/node]
 6: v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments, v8::internal::Isolate*) [/usr/local/bin/node]
 7: 0x26aa11c0427d
 8: 0x26aa11c0f755
 9: 0x26aa11c8bc20
10: 0x26aa11c144f7
11: 0x26aa11c144f7
Abort trap: 6```