### PR TITLE
Refactored the gulpfile

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -12,14 +12,15 @@ const   $ = gulpLoadPlugins(),
         browserSync = require('browser-sync').create(),
         isProduction = process.env.NODE_ENV === 'production';
 
+let     suppressHugoErrors = false;
 
+
+//-- IMPORTANT
 //error handler
 function onError(err) {
     console.log(err.message);
     this.emit('end');
 }
-
-let suppressHugoErrors = false;
 
 // start browsersync
 gulp.task('browser-sync', () => {
@@ -31,6 +32,8 @@ gulp.task('browser-sync', () => {
     });
 });
 
+
+//-- RUN
 //start the server
 gulp.task('server', ['build', 'browser-sync'], () => {
     suppressHugoErrors = true;
@@ -58,6 +61,8 @@ gulp.task('build-preview', () => {
     runSequence('pub-delete', ['sass', 'js', 'fonts', 'images', 'build-functions'], 'hugo-preview')
 })
 
+
+//-- BUILD
 //build functions
 gulp.task('build-functions', (cb) => {
 
@@ -82,7 +87,8 @@ gulp.task('build-functions', (cb) => {
 
 })
 
-//hugo task
+//-- hugo tasks
+//hugo
 gulp.task('hugo', (cb) => {
     let baseUrl = process.env.NODE_ENV === 'production' ? process.env.URL : process.env.DEPLOY_PRIME_URL;
     let args = baseUrl ? ['-b', baseUrl] : [];

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -136,7 +136,7 @@ gulp.task('sass', () => {
     .pipe($.autoprefixer(['ie >= 10', 'last 2 versions']))
     .pipe($.if(isProduction, $.cssnano({ discardUnused: false, minifyFontValues: false })))
     .pipe($.size({ gzip: true, showFiles: true }))
-    .pipe(gulp.dest('static/css'))
+    .pipe($.if(isProduction, gulp.dest('static/css'), gulp.dest('public/css'))) // if build process is not production, simply put the css in the public folder and don't rebuild hugo ( so the page doesn't auto reload)
     .pipe(browserSync.stream())
 })
 


### PR DESCRIPTION
- I updated onError() so it can swallow all errors gracefully with the addition of `this.emit('end');`. I had to make it a regular function as I think the way it was written was also messing with the error handling.
- I removed $.watch and the init-watch function and replaced the instances with gulp.watch(). I know it's not DRY but I think the sequence was affecting the build process.
- I replaced gulp.start() with the conventional way to run tasks in sequence (gulp.start() is not recommended, see here: https://github.com/gulpjs/gulp/issues/426)
- I commented out print() on the sass and js functions as I feel like these are redundant and take up valuable terminal real estate.
- I added verbose:true to the imagemin task and removed print() so it is easier to see what files are changed visually using the imagemin plugin instead.
- I added a browsersync as a task so it can be used multiple times
- I updated the order of the functions and added comments for better readability