### PR TITLE
Updated how CSS is watched in development mode (so the page doesn't refresh after styles have been injected)

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -48,7 +48,7 @@ gulp.task('server:with-drafts', ['build-preview', 'browser-sync'], () => {
     gulp.watch('src/sass/**/*.scss', ['sass'])
     gulp.watch('src/js/**/*.js', ['js-watch'])
     gulp.watch('src/images/**/*', ['images'])
-    gulp.watch(['archetypes/**/*', 'data/**/*', 'content/**/*', 'layouts/**/*', 'static/**/*', 'config.toml'], ['hugo-preview'])
+    gulp.watch(['archetypes/**/*', 'data/**/*', 'content/**/*', 'layouts/**/*', 'static/!(css)**/*', 'config.toml'], ['hugo-preview'])
 });
 
 //build the site

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -40,7 +40,7 @@ gulp.task('server', ['build', 'browser-sync'], () => {
     gulp.watch('src/sass/**/*.scss', ['sass'])
     gulp.watch('src/js/**/*.js', ['js-watch'])
     gulp.watch('src/images/**/*', ['images'])
-    gulp.watch(['archetypes/**/*', 'data/**/*', 'content/**/*', 'layouts/**/*', 'static/**/*', 'config.toml'], ['hugo'])
+    gulp.watch(['archetypes/**/*', 'data/**/*', 'content/**/*', 'layouts/**/*', 'static/!(css)**/*', 'config.toml'], ['hugo'])
 });
 
 //start the server: with drafts

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -48,7 +48,7 @@ gulp.task('server:with-drafts', ['build-preview', 'browser-sync'], () => {
     gulp.watch('src/sass/**/*.scss', ['sass'])
     gulp.watch('src/js/**/*.js', ['js-watch'])
     gulp.watch('src/images/**/*', ['images'])
-    gulp.watch(['archetypes/**/*', 'data/**/*', 'content/**/*', 'layouts/**/*', 'static/!(css)**/*', 'config.toml'], ['hugo'])
+    gulp.watch(['archetypes/**/*', 'data/**/*', 'content/**/*', 'layouts/**/*', 'static/**/*', 'config.toml'], ['hugo-preview'])
 });
 
 //build the site
@@ -136,7 +136,7 @@ gulp.task('sass', () => {
     .pipe($.autoprefixer(['ie >= 10', 'last 2 versions']))
     .pipe($.if(isProduction, $.cssnano({ discardUnused: false, minifyFontValues: false })))
     .pipe($.size({ gzip: true, showFiles: true }))
-    .pipe(gulp.dest('static/css')) // if build process is not production, simply put the css in the public folder and don't rebuild hugo ( so the page doesn't auto reload)
+    .pipe($.if(isProduction, gulp.dest('static/css'), gulp.dest('public/css'))) // if build process is not production, simply put the css in the public folder and don't rebuild hugo ( so the page doesn't auto reload)
     .pipe(browserSync.stream())
 })
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -48,7 +48,7 @@ gulp.task('server:with-drafts', ['build-preview', 'browser-sync'], () => {
     gulp.watch('src/sass/**/*.scss', ['sass'])
     gulp.watch('src/js/**/*.js', ['js-watch'])
     gulp.watch('src/images/**/*', ['images'])
-    gulp.watch(['archetypes/**/*', 'data/**/*', 'content/**/*', 'layouts/**/*', 'static/**/*', 'config.toml'], ['hugo-preview'])
+    gulp.watch(['archetypes/**/*', 'data/**/*', 'content/**/*', 'layouts/**/*', 'static/!(css)**/*', 'config.toml'], ['hugo'])
 });
 
 //build the site
@@ -136,7 +136,7 @@ gulp.task('sass', () => {
     .pipe($.autoprefixer(['ie >= 10', 'last 2 versions']))
     .pipe($.if(isProduction, $.cssnano({ discardUnused: false, minifyFontValues: false })))
     .pipe($.size({ gzip: true, showFiles: true }))
-    .pipe($.if(isProduction, gulp.dest('static/css'), gulp.dest('public/css'))) // if build process is not production, simply put the css in the public folder and don't rebuild hugo ( so the page doesn't auto reload)
+    .pipe(gulp.dest('static/css')) // if build process is not production, simply put the css in the public folder and don't rebuild hugo ( so the page doesn't auto reload)
     .pipe(browserSync.stream())
 })
 


### PR DESCRIPTION
Hello, sorry I know you just merged my PR today but I forgot to fix something else (my mistake).

Previously, the CSS would be injected and then the page would refresh from the hugo task being triggered. This was annoying me as I was developing my site because I had a few hidden elements I wanted to style but the page would keep refreshing after style changes were made.

I had updated the script with an if condition in the sass task, but I forgot to update the watch args so that both the css and other files are both up to date as you develop (the way I had wrote it before was not complete as it was missing the `static/!(css)**/*` glob). Hope that makes sense >.<