### PR TITLE
Fix issue with incorrect sitemap URLs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-    command = "npm run build"
+    command = "hugo -b $URL && npm run build:functions"
     publish = "public"
     functions = "functions"
 
@@ -11,4 +11,7 @@
     NODE_ENV = "production"
 
 [context.deploy-preview]
-    command = "npm run build:preview"
+    command = "hugo -b $DEPLOY_PRIME_URL"
+
+[context.branch-deploy]
+    command = "hugo -b $DEPLOY_PRIME_URL"

--- a/package.json
+++ b/package.json
@@ -2,11 +2,10 @@
   "name": "atlas",
   "private": true,
   "scripts": {
-    "build": "hugo",
-    "build:preview": "hugo --buildFuture",
     "start": "hugo server",
-    "server": "hugo server",
-    "server:with-drafts": "hugo server --buildFuture"
+    "build": "hugo && npm run build:functions",
+    "build:functions": "netlify-lambda build assets/lambda",
+    "server": "hugo server"
   },
   "dependencies": {
     "autoprefixer": "^9.5.0",


### PR DESCRIPTION
Since the update to Gulp, it looks like the sitemap urls are incorrect.

Hopefully this fixes it, and loads in the correct Netlify URL from their ENV variables.