### PR TITLE
Add example lambda to assets (Fixes #78)

### DIFF
--- a/assets/lambda/hello.js
+++ b/assets/lambda/hello.js
@@ -1,0 +1,11 @@
+exports.handler = (event, context, callback) => {
+    callback(null, {
+        statusCode: 200,
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            message: "Hi from Lambda."
+        })
+    });
+}


### PR DESCRIPTION
This is not the most orthodox way of fixing things, but it works, and it contains a working example for people to start using lambda functions 

As mentioned in #78 the netlify build fails unless there's at least one lambda function. We should in the future edit the the build command, but for now this works.

Fixes #78 